### PR TITLE
GitHub Actionsの追加: 2回実行して画像比較

### DIFF
--- a/.github/workflows/compare-runs.yml
+++ b/.github/workflows/compare-runs.yml
@@ -1,0 +1,56 @@
+name: Compare Two Runs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: 'true'
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+      PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium-browser
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            chromium-browser \
+            build-essential \
+            libcairo2-dev \
+            libjpeg-dev \
+            libpango1.0-dev \
+            libgif-dev
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build scripts
+        run: npm run build
+
+      - name: Prepare configs
+        run: |
+          cp env/screenshot.yml screenshot.yml
+          cp env/diff.yml diff.yml
+
+      - name: First capture (run1)
+        run: |
+          sed -i 's/subdirectory:.*/subdirectory: run1/' screenshot.yml
+          node dist/screenshot.js
+
+      - name: Second capture (run2)
+        run: |
+          sed -i 's/subdirectory:.*/subdirectory: run2/' screenshot.yml
+          node dist/screenshot.js
+
+      - name: Compare images
+        run: |
+          sed -i 's/source_directory:.*/source_directory: run1/' diff.yml
+          sed -i 's/target_directory:.*/target_directory: run2/' diff.yml
+          node dist/diff.js

--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ npm run test:basic
 ```
 docker-compose exec app npm test -- build.test.ts
 ```
+
+## GitHub Actionsでの2回連続比較
+
+リポジトリには1回のワークフロー内でスクリーンショットを2回取得し、差分比較を行う例として `compare-runs.yml` を用意しています。永続的なストレージを使わず、実行環境の一時領域のみを利用するため課金は発生しません。
+
+1. `compare-runs.yml` は手動トリガー (`workflow_dispatch`) で実行できます。
+2. ワークフロー内で `screenshot.yml` の `output.subdirectory` を `run1`、`run2` と書き換え、それぞれ `node dist/screenshot.js` を実行します。
+3. 最後に `diff.yml` の比較対象を `run1` と `run2` に設定して `node dist/diff.js` を実行し、`output/diff` に結果を出力します。
+
+結果の画像はジョブ終了後に削除されるため、必要に応じて処理内で利用してください。


### PR DESCRIPTION
## 変更点
- 一つのワークフロー内でスクリーンショットを2回取得し差分を比較する `compare-runs.yml` を追加
- ワークフローの利用方法を README に追記

## テスト結果
- `npm ci` 実行後、`npm test` が全て成功
- `npm run build` 実行で TypeScript コンパイルが成功

------
https://chatgpt.com/codex/tasks/task_e_6851364d1c6c83218f9779deab540dde