### PR TITLE
シナリオwait・テスト改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 dist/
 output/
+# env ディレクトリの追加ファイルは管理しない
+env/*
+!env/diff.yml
+!env/screenshot.yml

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ actions:
     screenshot: step2
   - action: click
     selector: '#login'
+    wait: 500 # スクリーンショット前に待機
     screenshot: step3
   - action: wait
     wait: 1000 # ミリ秒
@@ -97,7 +98,7 @@ testuser2,30
 | action | 必須オプション | その他のオプション | 説明 |
 | ------ | ------------- | ------------------ | ---- |
 | `goto` | `url` | `timeout`, `screenshot` | 指定したURLへ遷移します |
-| `click` | `selector` | `timeout`, `screenshot` | CSSセレクタで指定した要素をクリックします。遷移を伴う場合`timeout`で待ち時間を上書きできます |
+| `click` | `selector` | `timeout`, `wait`, `screenshot` | CSSセレクタで指定した要素をクリックします。`wait`を指定するとクリック後にそのミリ秒分待ってからスクリーンショットを撮ります。遷移を伴う場合`timeout`で待ち時間を上書きできます |
 | `type` | `selector`, `text` | `screenshot` | テキストを入力します。`${変数}`でCSVの値を利用できます |
 | `wait` | `wait` | `screenshot` | 指定ミリ秒だけ待機します |
 

--- a/__tests__/scenario.test.ts
+++ b/__tests__/scenario.test.ts
@@ -70,7 +70,7 @@ describe('runScenario', () => {
       actions: [
         { action: 'goto', url: `http://localhost:${port}/` },
         { action: 'type', selector: '#user', text: '${name}' },
-        { action: 'click', selector: '#login' },
+        { action: 'click', selector: '#login', wait: 150 },
         { action: 'wait', wait: 100 }
       ]
     };
@@ -85,6 +85,8 @@ describe('runScenario', () => {
     expect(puppeteerAny.goto).toHaveBeenCalled();
     expect(puppeteerAny.type).toHaveBeenCalledWith('#user', 'alice');
     expect(puppeteerAny.click).toHaveBeenCalledWith('#login');
+    expect(puppeteerAny.waitForTimeout).toHaveBeenCalledWith(150);
+    expect(puppeteerAny.waitForTimeout).toHaveBeenCalledWith(100);
     expect(puppeteerAny.screenshot.mock.calls.length).toBe(4);
   });
 
@@ -107,6 +109,7 @@ describe('runScenario', () => {
 
     const mod = await import('../src/scenario.js');
     await mod.runScenario(scenarioPath, paramsPath, outputDir, puppeteerAny);
+    expect(puppeteerAny.waitForTimeout).toHaveBeenCalledWith(50);
     expect(puppeteerAny.screenshot.mock.calls.length).toBe(1);
   });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./output:/usr/src/app/output
-      - ./env/diff.yml:/usr/src/app/env/diff.yml:ro
-      - ./env/screenshot.yml:/usr/src/app/env/screenshot.yml:ro
+      - ./env:/usr/src/app/env:ro
     environment:
       - NODE_ENV=production
     init: true

--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -8,7 +8,7 @@ interface ScenarioAction {
   url?: string;
   selector?: string;
   text?: string;
-  /** waitアクションで指定する待機ミリ秒 */
+  /** waitアクションやclickアクションで使用する待機ミリ秒 */
   wait?: number;
   timeout?: number;
   /**
@@ -61,6 +61,9 @@ async function runAction(page: Page, action: ScenarioAction, params: Params, def
           page.waitForNavigation({ waitUntil: 'networkidle2', timeout }).catch(() => {}),
           page.click(action.selector)
         ]);
+        if (typeof action.wait === 'number') {
+          await (page as any).waitForTimeout(action.wait);
+        }
         break;
       case 'type':
         if (!action.selector || action.text === undefined) throw new Error('type requires selector and text');


### PR DESCRIPTION
## 変更点
- READMEのシナリオ例にclick後の待機オプションを追記
- アクション一覧表に`wait`オプションを追加
- `scenario.test.ts`で`waitForTimeout`が呼ばれることを確認するテストを追加

## テスト
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a4c9e6d70832187e76c31c0902667