### PR TITLE
wait機能をsleepで実装

### DIFF
--- a/__tests__/scenario.test.ts
+++ b/__tests__/scenario.test.ts
@@ -9,9 +9,8 @@ const goto = jest.fn();
 const click = jest.fn();
 const type = jest.fn();
 const screenshot = jest.fn();
-const waitForTimeout = jest.fn();
 const waitForNavigation = jest.fn(() => Promise.resolve());
-const page = { goto, click, type, screenshot, waitForTimeout, waitForNavigation };
+const page = { goto, click, type, screenshot, waitForNavigation };
 const newPage = jest.fn(async () => page);
 const close = jest.fn();
 const browser = { newPage, close };
@@ -23,7 +22,7 @@ jest.mock('puppeteer', () => ({
   launch
 }));
 
-const puppeteerAny = { launch, newPage, goto, click, type, screenshot, waitForTimeout } as any;
+const puppeteerAny = { launch, newPage, goto, click, type, screenshot } as any;
 
 
 let server: http.Server;
@@ -85,8 +84,6 @@ describe('runScenario', () => {
     expect(puppeteerAny.goto).toHaveBeenCalled();
     expect(puppeteerAny.type).toHaveBeenCalledWith('#user', 'alice');
     expect(puppeteerAny.click).toHaveBeenCalledWith('#login');
-    expect(puppeteerAny.waitForTimeout).toHaveBeenCalledWith(150);
-    expect(puppeteerAny.waitForTimeout).toHaveBeenCalledWith(100);
     expect(puppeteerAny.screenshot.mock.calls.length).toBe(4);
   });
 
@@ -109,7 +106,6 @@ describe('runScenario', () => {
 
     const mod = await import('../src/scenario.js');
     await mod.runScenario(scenarioPath, paramsPath, outputDir, puppeteerAny);
-    expect(puppeteerAny.waitForTimeout).toHaveBeenCalledWith(50);
     expect(puppeteerAny.screenshot.mock.calls.length).toBe(1);
   });
 

--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -3,6 +3,11 @@ import * as path from 'path';
 import puppeteer, { Page } from 'puppeteer';
 import * as yaml from 'yaml';
 
+// 指定ミリ秒だけ待機するユーティリティ
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 interface ScenarioAction {
   action: string;
   url?: string;
@@ -62,7 +67,7 @@ async function runAction(page: Page, action: ScenarioAction, params: Params, def
           page.click(action.selector)
         ]);
         if (typeof action.wait === 'number') {
-          await (page as any).waitForTimeout(action.wait);
+          await sleep(action.wait);
         }
         break;
       case 'type':
@@ -71,7 +76,7 @@ async function runAction(page: Page, action: ScenarioAction, params: Params, def
         break;
       case 'wait':
         if (typeof action.wait !== 'number') throw new Error('wait requires time');
-        await (page as any).waitForTimeout(action.wait);
+        await sleep(action.wait);
         break;
       default:
         throw new Error(`Unknown action: ${action.action}`);


### PR DESCRIPTION
## 概要
`waitForTimeout` が正常に待機しない問題があったため、`setTimeout` を利用した `sleep` 関数で待ち時間を実現しました。それに伴いテストも更新しました。

## 主な変更点
- `scenario.ts` に `sleep` 関数を追加し、`waitForTimeout` の呼び出しを置き換え
- `scenario.test.ts` から `waitForTimeout` 関連のモックと検証を削除

## テスト
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a5519efc0832184264903114036a4