### PR TITLE
シナリオ出力をフラットに保存

### DIFF
--- a/__tests__/scenario-diff.test.ts
+++ b/__tests__/scenario-diff.test.ts
@@ -33,11 +33,8 @@ describe('diffScenario', () => {
     const dir1 = fs.mkdtempSync(path.join(process.cwd(), 'sdiff1-'));
     const dir2 = fs.mkdtempSync(path.join(process.cwd(), 'sdiff2-'));
     tmpDirs.push(dir1, dir2);
-    const s1 = path.join(dir1, '0');
-    const s2 = path.join(dir2, '0');
-    fs.mkdirSync(s1); fs.mkdirSync(s2);
-    const f1 = path.join(s1, '1-1.png');
-    const f2 = path.join(s2, '1-1.png');
+    const f1 = path.join(dir1, '1-1.png');
+    const f2 = path.join(dir2, '1-1.png');
     createPng(f1, 0);
     createPng(f2, 0);
     const result = mod.diffScenario(dir1, dir2, 0.1);
@@ -48,11 +45,8 @@ describe('diffScenario', () => {
     const dir1 = fs.mkdtempSync(path.join(process.cwd(), 'sdiff3-'));
     const dir2 = fs.mkdtempSync(path.join(process.cwd(), 'sdiff4-'));
     tmpDirs.push(dir1, dir2);
-    const s1 = path.join(dir1, '0');
-    const s2 = path.join(dir2, '0');
-    fs.mkdirSync(s1); fs.mkdirSync(s2);
-    const f1 = path.join(s1, '1-1.png');
-    const f2 = path.join(s2, '1-1.png');
+    const f1 = path.join(dir1, '1-1.png');
+    const f2 = path.join(dir2, '1-1.png');
     createPng(f1, 0);
     createPng(f2, 255);
     const result = mod.diffScenario(dir1, dir2, 0.1);

--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -106,17 +106,17 @@ export async function runScenario(
   const records = parseCsv(paramsFile);
   const defaultTimeout = scenario.defaultTimeout ?? 10000;
 
+  fs.mkdirSync(outputBase, { recursive: true });
+
   for (let i = 0; i < records.length; i++) {
     const params = records[i];
-    const runDir = path.join(outputBase, `${i}`);
-    fs.mkdirSync(runDir, { recursive: true });
 
     const browser = await puppeteerLib.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     const page = await browser.newPage();
     try {
       for (let j = 0; j < scenario.actions.length; j++) {
         const action = scenario.actions[j];
-        await runAction(page, action, params, defaultTimeout, runDir, i, j);
+        await runAction(page, action, params, defaultTimeout, outputBase, i, j);
       }
     } catch (e) {
       console.error('Scenario aborted due to error');


### PR DESCRIPTION
## 変更内容
- `runScenario` で作成していた実行毎のサブディレクトリを廃止
- シナリオ結果を指定ディレクトリ直下へ保存するよう修正
- テスト `scenario-diff.test.ts` を新しい保存形式に合わせて更新

## テスト結果
- `npm test` を実行し全 15 スイートが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_685a624e84788321ab160d80b2940d35