### PR TITLE
シナリオ実行時の進行ログを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ docker-compose exec app node dist/scenario.js --scenario env/scenario.yml --para
 ```
 
 `--output` (または `-o`) オプションで保存先ディレクトリを指定します。
+実行中は各アクションの結果が順次コンソールに表示されます。
 
 `scenario.yml`例:
 ```yaml

--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -52,8 +52,18 @@ function substitute(template: string, params: Params): string {
   return template.replace(/\${(.*?)}/g, (_, key) => params[key] ?? '');
 }
 
-async function runAction(page: Page, action: ScenarioAction, params: Params, defaultTimeout: number, outputDir: string, rowIndex: number, actionIndex: number) {
+async function runAction(
+  page: Page,
+  action: ScenarioAction,
+  params: Params,
+  defaultTimeout: number,
+  outputDir: string,
+  rowIndex: number,
+  actionIndex: number
+) {
   const timeout = action.timeout ?? defaultTimeout;
+  const label = `${rowIndex + 1}-${actionIndex + 1}`;
+  console.log(`[${label}] ${action.action} 開始`);
   try {
     switch (action.action) {
       case 'goto':
@@ -92,6 +102,9 @@ async function runAction(page: Page, action: ScenarioAction, params: Params, def
       if (fs.existsSync(file)) {
         fs.chmodSync(file, 0o666);
       }
+      console.log(`[${label}] スクリーンショット保存: ${file}`);
+    } else {
+      console.log(`[${label}] 完了`);
     }
   } catch (e) {
     console.error('Action failed:', e);
@@ -111,9 +124,11 @@ export async function runScenario(
 
   fs.mkdirSync(outputBase, { recursive: true, mode: 0o777 });
   fs.chmodSync(outputBase, 0o777);
+  console.log(`Output directory: ${outputBase}`);
 
   for (let i = 0; i < records.length; i++) {
     const params = records[i];
+    console.log(`---- ${i + 1} 行目開始 ----`);
 
     const browser = await puppeteerLib.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     const page = await browser.newPage();
@@ -126,6 +141,7 @@ export async function runScenario(
       console.error('Scenario aborted due to error');
     } finally {
       await browser.close();
+      console.log(`---- ${i + 1} 行目終了 ----`);
     }
   }
 }


### PR DESCRIPTION
## 概要
- シナリオ実行中に各アクションの開始・終了をコンソールへ表示
- 実行対象ディレクトリや行の区切りを出力
- README に実行時に結果が順次表示される旨を追記

## テスト結果
- `npm test` を実行し、全 15 スイートが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_685a89fd567483219fad43fc674385a4