### PR TITLE
シナリオ比較時の不要なdiff実行を修正

### DIFF
--- a/__tests__/scenario-diff-cli.test.ts
+++ b/__tests__/scenario-diff-cli.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const execFileAsync = promisify(execFile);
+
+const srcScript = path.join(process.cwd(), 'src', 'scenarioDiff.ts');
+
+// ts-nodeを利用して直接実行するためビルドは不要
+beforeAll(async () => {
+  // 依存解決のためにnode_modulesが存在することだけ確認
+  if (!fs.existsSync('node_modules')) {
+    await execFileAsync('npm', ['ci']);
+  }
+}, 30000);
+
+describe('scenarioDiff CLI integration', () => {
+  it('指定ディレクトリが存在しない場合エラー表示のみを行う', async () => {
+    const { stdout, stderr } = await execFileAsync('node', [
+      '--loader',
+      'ts-node/esm',
+      srcScript,
+      '--old',
+      'missing1',
+      '--new',
+      'missing2'
+    ], {
+      encoding: 'utf8',
+      env: { ...process.env, JEST_WORKER_ID: undefined, NODE_ENV: 'production' }
+    });
+    const output = (stdout || '') + (stderr || '');
+    expect(output).toContain('ディレクトリが存在しません: missing1');
+    expect(output).not.toContain('output/old');
+  });
+});

--- a/__tests__/scenario-diff.test.ts
+++ b/__tests__/scenario-diff.test.ts
@@ -70,4 +70,15 @@ describe('diffScenario', () => {
     expect(output).toContain('一致');
     logSpy.mockRestore();
   });
+
+  it('存在しないディレクトリが指定された場合はfalseを返す', () => {
+    const missingDir = path.join(process.cwd(), 'no-such-dir');
+    const dir2 = fs.mkdtempSync(path.join(process.cwd(), 'sdiff-missing-'));
+    tmpDirs.push(dir2);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const result = mod.diffScenario(missingDir, dir2, 0.1);
+    expect(result).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,6 +1,7 @@
 import { loadDiffConfig } from './types/config.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { pathToFileURL } from 'url';
 import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
@@ -123,9 +124,14 @@ export function main() {
   }
 }
 
-// テスト環境ではない場合のみmain関数を実行
+// コマンドラインから直接呼び出された場合のみmain関数を実行
 // Jest環境やDockerテスト環境では実行しない
-if (process.env.NODE_ENV !== 'test' && !process.env.JEST_WORKER_ID && !process.env.TEST_IN_DOCKER) {
+if (
+  import.meta.url === pathToFileURL(process.argv[1]).href &&
+  process.env.NODE_ENV !== 'test' &&
+  !process.env.JEST_WORKER_ID &&
+  !process.env.TEST_IN_DOCKER
+) {
   main();
 }
 

--- a/src/scenarioDiff.ts
+++ b/src/scenarioDiff.ts
@@ -21,6 +21,15 @@ function gatherPngFiles(dir: string): string[] {
 }
 
 export function diffScenario(oldDir: string, newDir: string, threshold = 0.1): boolean {
+  if (!fs.existsSync(oldDir)) {
+    console.error(`ディレクトリが存在しません: ${oldDir}`);
+    return false;
+  }
+  if (!fs.existsSync(newDir)) {
+    console.error(`ディレクトリが存在しません: ${newDir}`);
+    return false;
+  }
+
   let allMatch = true;
   const oldFiles = gatherPngFiles(oldDir);
   for (const oldFile of oldFiles) {


### PR DESCRIPTION
## 変更内容
- `diff.ts` がインポート時に `main()` を実行してしまう問題を修正
  - 直接実行された場合のみ `main()` を起動するよう判定処理を追加
- 上記挙動を確認する CLI テスト `scenario-diff-cli.test.ts` を追加

## テスト結果
- `npm test` で全 16 スイート成功


------
https://chatgpt.com/codex/tasks/task_e_685b428cb8a08321bd493668ff7f0365