### PR TITLE
ヘッドレス起動オプション追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ docker-compose exec app node dist/screenshot.js
 YMLで定義したシナリオとCSVのパラメータを組み合わせてアクションごとに画面を保存します。
 
 ```bash
-docker-compose exec app node dist/scenario.js --scenario env/scenario.yml --params env/params.csv --output output/run1
+docker-compose exec app node dist/scenario.js --scenario env/scenario.yml --params env/params.csv --output output/run1 [--headless false]
 ```
 
 `--output` (または `-o`) オプションで保存先ディレクトリを指定します。
+`--headless` に `false` を指定するとブラウザを表示したまま実行できます。
 実行中は各アクションの結果が順次コンソールに表示されます。
 
 `scenario.yml`例:

--- a/__tests__/scenario.test.ts
+++ b/__tests__/scenario.test.ts
@@ -78,7 +78,7 @@ describe('runScenario', () => {
     fs.mkdirSync(outputDir);
 
     const mod = await import('../src/scenario.js');
-    await mod.runScenario(scenarioPath, paramsPath, outputDir, puppeteerAny);
+    await mod.runScenario(scenarioPath, paramsPath, outputDir, true, puppeteerAny);
     expect(launch).toHaveBeenCalled();
     expect(puppeteerAny.newPage).toHaveBeenCalled();
     expect(puppeteerAny.goto).toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe('runScenario', () => {
     fs.mkdirSync(outputDir);
 
     const mod = await import('../src/scenario.js');
-    await mod.runScenario(scenarioPath, paramsPath, outputDir, puppeteerAny);
+    await mod.runScenario(scenarioPath, paramsPath, outputDir, true, puppeteerAny);
     expect(puppeteerAny.screenshot.mock.calls.length).toBe(1);
   });
 
@@ -120,6 +120,20 @@ describe('runScenario', () => {
     const mod = await import('../src/scenario.js');
     const outDir = path.join(tmp, 'out');
     const result = mod.parseArgs(['--scenario', scenarioPath, '--params', paramsPath, '--output', outDir]);
-    expect(result).toEqual({ scenarioPath, paramsPath, outputDir: outDir });
+    expect(result).toEqual({ scenarioPath, paramsPath, outputDir: outDir, headless: true });
+  });
+
+  it('--headlessオプションをfalseで解釈できる', async () => {
+    const tmp = fs.mkdtempSync(path.join(process.cwd(), 'scenario-cli-h-'));
+    tmpDirs.push(tmp);
+    const scenarioPath = path.join(tmp, 'sc.yml');
+    const paramsPath = path.join(tmp, 'pr.csv');
+    fs.writeFileSync(scenarioPath, yaml.stringify({ actions: [] }));
+    fs.writeFileSync(paramsPath, 'a\n1\n');
+
+    const mod = await import('../src/scenario.js');
+    const outDir = path.join(tmp, 'out');
+    const result = mod.parseArgs(['--scenario', scenarioPath, '--params', paramsPath, '--output', outDir, '--headless', 'false']);
+    expect(result).toEqual({ scenarioPath, paramsPath, outputDir: outDir, headless: false });
   });
 });


### PR DESCRIPTION
## 概要
- `src/scenario.ts` に `--headless` オプションを追加し、Puppeteer の `launch` に渡せるよう変更
- CLI 引数解析および `main` 関数を更新
- README にオプションの使い方を追記
- テストを修正し `--headless` オプションの解析を確認

## テスト結果
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b65ffe3d0832196d4b1c1a7ce33fe