### PR TITLE
READMEにリモートChrome利用の条件を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,25 @@ PUPPETEER_SKIP_DOWNLOAD=1 npm install
 ```
 
 ### リモートChromeへの接続
-`--headless false` を指定してブラウザを表示したまま操作したい場合は、ホスト側で Chrome をリモートデバッグモードで起動しておくとコンテナから既存のブラウザに接続できます。
+`--headless false` を指定してブラウザを表示したまま操作したい場合は、ホスト側で Chrome をリモートデバッグモードで起動しておきます。PowerShell でも bash でも起動できます。
 
+#### PowerShell の例
+```powershell
+$TMP = "$env:TEMP\chrome_debug_$([guid]::NewGuid())"
+& "$Env:ProgramFiles\Google\Chrome\Application\chrome.exe" `
+   --remote-debugging-port=9222 `
+   --user-data-dir="$TMP" `
+   about:blank
+```
+
+#### bash の例
 ```bash
-chrome --remote-debugging-port=9222
+# 空のユーザーデータディレクトリを用意
+TMP=$(mktemp -d -t chrome-debug-XXXX)
+google-chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$TMP" \
+  about:blank
 ```
 
 起動後、 `http://localhost:9222/json/version` で表示される `webSocketDebuggerUrl` を `PUPPETEER_WS_ENDPOINT` 環境変数に設定してください。

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Chrome のダウンロードを省略したいなど、ローカルでテスト�
 PUPPETEER_SKIP_DOWNLOAD=1 npm install
 ```
 
+### リモートChromeへの接続
+`--headless false` を指定してブラウザを表示したまま操作したい場合は、ホスト側で Chrome をリモートデバッグモードで起動しておくとコンテナから既存のブラウザに接続できます。
+
+```bash
+chrome --remote-debugging-port=9222
+```
+
+起動後、 `http://localhost:9222/json/version` で表示される `webSocketDebuggerUrl` を `PUPPETEER_WS_ENDPOINT` 環境変数に設定してください。
+
 ### 設定
 `env/screenshot.yml`:
 ```
@@ -51,11 +60,23 @@ threshold: 0.1 # 実行時オプションで変更可
 docker-compose exec app node dist/screenshot.js
 ```
 
+リモートChromeを利用する場合の例 (事前にホスト側でリモートデバッグモードの Chrome を起動しておく必要があります):
+
+```bash
+PUPPETEER_WS_ENDPOINT=ws://host.docker.internal:9222/devtools/browser/<id> docker-compose exec app node dist/screenshot.js
+```
+
 ### シナリオに沿ったスクリーンショット
 YMLで定義したシナリオとCSVのパラメータを組み合わせてアクションごとに画面を保存します。
 
 ```bash
 docker-compose exec app node dist/scenario.js --scenario env/scenario.yml --params env/params.csv --output output/run1 [--headless false]
+```
+
+リモートChromeを利用する場合の例 (事前にホスト側でリモートデバッグモードの Chrome を起動しておく必要があります):
+
+```bash
+PUPPETEER_WS_ENDPOINT=ws://host.docker.internal:9222/devtools/browser/<id> docker-compose exec app node dist/scenario.js --scenario env/scenario.yml --params env/params.csv --output output/run1
 ```
 
 `--output` (または `-o`) オプションで保存先ディレクトリを指定します。

--- a/__mocks__/puppeteer.ts
+++ b/__mocks__/puppeteer.ts
@@ -22,5 +22,6 @@ export const newPage = jest.fn(async () => page);
 export const close = jest.fn();
 export const browser = { newPage, close };
 export const launch = jest.fn(async () => browser);
+export const connect = jest.fn(async () => browser);
 
-export default { launch };
+export default { launch, connect };

--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -1,6 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import puppeteer, { Page } from 'puppeteer';
+
+function connectOrLaunch(puppeteerLib: typeof puppeteer, headless: boolean) {
+  const ws = process.env.PUPPETEER_WS_ENDPOINT || process.env.WS_ENDPOINT;
+  if (ws) {
+    return puppeteerLib.connect({ browserWSEndpoint: ws });
+  }
+  return puppeteerLib.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    headless
+  });
+}
 import * as yaml from 'yaml';
 
 // 指定ミリ秒だけ待機するユーティリティ
@@ -131,10 +142,7 @@ export async function runScenario(
     const params = records[i];
     console.log(`---- ${i + 1} 行目開始 ----`);
 
-    const browser = await puppeteerLib.launch({
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      headless
-    });
+    const browser = await connectOrLaunch(puppeteerLib, headless);
     const page = await browser.newPage();
     try {
       for (let j = 0; j < scenario.actions.length; j++) {

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -3,13 +3,21 @@ import * as fs from 'fs';
 import * as path from 'path';
 import puppeteer from 'puppeteer';
 
+function connectOrLaunch() {
+  const ws = process.env.PUPPETEER_WS_ENDPOINT || process.env.WS_ENDPOINT;
+  if (ws) {
+    return puppeteer.connect({ browserWSEndpoint: ws });
+  }
+  return puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+}
+
 // テスト用にエクスポート
 export async function takeScreenshot(url: string, outputPath: string): Promise<void> {
   let browser = null;
   try {
-    browser = await puppeteer.launch({
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    });
+    browser = await connectOrLaunch();
     const page = await browser.newPage();
     await page.goto(url, { 
       waitUntil: 'networkidle2',


### PR DESCRIPTION
## 概要
- リモートChrome接続手順の説明を `--headless false` を指定する場合に限定する旨を追記
- リモート利用時の各コマンド例に「事前にChromeをリモートデバッグモードで起動しておく必要がある」旨を明記

## テスト
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b81d815a483218484135d480ce98c