### PR TITLE
リモートChrome機能を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,30 +25,6 @@ Chrome のダウンロードを省略したいなど、ローカルでテスト�
 PUPPETEER_SKIP_DOWNLOAD=1 npm install
 ```
 
-### リモートChromeへの接続
-`--headless false` を指定してブラウザを表示したまま操作したい場合は、ホスト側で Chrome をリモートデバッグモードで起動しておきます。PowerShell でも bash でも起動できます。
-
-#### PowerShell の例
-```powershell
-$TMP = "$env:TEMP\chrome_debug_$([guid]::NewGuid())"
-& "$Env:ProgramFiles\Google\Chrome\Application\chrome.exe" `
-   --remote-debugging-port=9222 `
-   --user-data-dir="$TMP" `
-   about:blank
-```
-
-#### bash の例
-```bash
-# 空のユーザーデータディレクトリを用意
-TMP=$(mktemp -d -t chrome-debug-XXXX)
-google-chrome \
-  --remote-debugging-port=9222 \
-  --user-data-dir="$TMP" \
-  about:blank
-```
-
-起動後、 `http://localhost:9222/json/version` で表示される `webSocketDebuggerUrl` を `PUPPETEER_WS_ENDPOINT` 環境変数に設定してください。
-
 ### 設定
 `env/screenshot.yml`:
 ```
@@ -75,23 +51,11 @@ threshold: 0.1 # 実行時オプションで変更可
 docker-compose exec app node dist/screenshot.js
 ```
 
-リモートChromeを利用する場合の例 (事前にホスト側でリモートデバッグモードの Chrome を起動しておく必要があります):
-
-```bash
-PUPPETEER_WS_ENDPOINT=ws://host.docker.internal:9222/devtools/browser/<id> docker-compose exec app node dist/screenshot.js
-```
-
 ### シナリオに沿ったスクリーンショット
 YMLで定義したシナリオとCSVのパラメータを組み合わせてアクションごとに画面を保存します。
 
 ```bash
 docker-compose exec app node dist/scenario.js --scenario env/scenario.yml --params env/params.csv --output output/run1 [--headless false]
-```
-
-リモートChromeを利用する場合の例 (事前にホスト側でリモートデバッグモードの Chrome を起動しておく必要があります):
-
-```bash
-PUPPETEER_WS_ENDPOINT=ws://host.docker.internal:9222/devtools/browser/<id> docker-compose exec app node dist/scenario.js --scenario env/scenario.yml --params env/params.csv --output output/run1
 ```
 
 `--output` (または `-o`) オプションで保存先ディレクトリを指定します。

--- a/__tests__/scenario.test.ts
+++ b/__tests__/scenario.test.ts
@@ -111,7 +111,7 @@ describe('runScenario', () => {
     expect(puppeteerAny.screenshot.mock.calls.length).toBe(1);
   });
 
-  it('PUPPETEER_WS_ENDPOINTがある場合connectを使用する', async () => {
+  it('PUPPETEER_WS_ENDPOINTが指定されてもlaunchを使用する', async () => {
     process.env.PUPPETEER_WS_ENDPOINT = 'ws://dummy';
     const tmp = fs.mkdtempSync(path.join(process.cwd(), 'scenario-connect-'));
     tmpDirs.push(tmp);
@@ -125,8 +125,8 @@ describe('runScenario', () => {
 
     const mod = await import('../src/scenario.js');
     await mod.runScenario(scenarioPath, paramsPath, outputDir, true, puppeteerAny);
-    expect(connect).toHaveBeenCalled();
-    expect(launch).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+    expect(launch).toHaveBeenCalled();
     delete process.env.PUPPETEER_WS_ENDPOINT;
   });
 

--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -2,11 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import puppeteer, { Page } from 'puppeteer';
 
-function connectOrLaunch(puppeteerLib: typeof puppeteer, headless: boolean) {
-  const ws = process.env.PUPPETEER_WS_ENDPOINT || process.env.WS_ENDPOINT;
-  if (ws) {
-    return puppeteerLib.connect({ browserWSEndpoint: ws });
-  }
+function launchBrowser(puppeteerLib: typeof puppeteer, headless: boolean) {
   return puppeteerLib.launch({
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
     headless
@@ -142,7 +138,7 @@ export async function runScenario(
     const params = records[i];
     console.log(`---- ${i + 1} 行目開始 ----`);
 
-    const browser = await connectOrLaunch(puppeteerLib, headless);
+    const browser = await launchBrowser(puppeteerLib, headless);
     const page = await browser.newPage();
     try {
       for (let j = 0; j < scenario.actions.length; j++) {

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -3,11 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import puppeteer from 'puppeteer';
 
-function connectOrLaunch() {
-  const ws = process.env.PUPPETEER_WS_ENDPOINT || process.env.WS_ENDPOINT;
-  if (ws) {
-    return puppeteer.connect({ browserWSEndpoint: ws });
-  }
+function launchBrowser() {
   return puppeteer.launch({
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
   });
@@ -17,7 +13,7 @@ function connectOrLaunch() {
 export async function takeScreenshot(url: string, outputPath: string): Promise<void> {
   let browser = null;
   try {
-    browser = await connectOrLaunch();
+    browser = await launchBrowser();
     const page = await browser.newPage();
     await page.goto(url, { 
       waitUntil: 'networkidle2',


### PR DESCRIPTION
## 概要
リモートChrome接続機能を利用しない方針となったため、関連コードとドキュメントを削除しました。

## 変更点
- `PUPPETEER_WS_ENDPOINT` 等の環境変数を利用した接続処理を廃止
- テストを修正し、常に `launch` が呼び出されることを確認
- README からリモートChromeに関する説明を削除

## テスト
- `npm install`
- `npm test` を実行し、全テストが成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_6863fe5ac0348321924e1afaed39a116