### PR TITLE
並列処理オプションのテスト修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ threshold: 0.1 # 実行時オプションで変更可
 ### スクリーンショットの撮影
 
 ```
-docker-compose exec app node dist/screenshot.js
+docker-compose exec app node dist/screenshot.js [--concurrency 3]
 ```
+`--concurrency` (または `-c`) で同時に実行するリクエスト数を指定できます。省略時は1件ずつ順番に処理します。
 
 ### シナリオに沿ったスクリーンショット
 YMLで定義したシナリオとCSVのパラメータを組み合わせてアクションごとに画面を保存します。

--- a/__tests__/concurrency.test.ts
+++ b/__tests__/concurrency.test.ts
@@ -1,0 +1,68 @@
+import { jest, describe, it, expect, afterEach, beforeAll, afterAll } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import http from 'http';
+const screenshotModule = await import('../src/screenshot.js');
+
+const tmpDirs: string[] = [];
+let server: http.Server;
+let port: number;
+
+beforeAll(done => {
+  server = http.createServer((_req, res) => {
+    res.end('<html><body>ok</body></html>');
+  }).listen(0, () => {
+    port = (server.address() as any).port;
+    done();
+  });
+});
+
+afterAll(done => {
+  server.close(done);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+
+describe('並列処理オプション', () => {
+  it('--concurrencyで指定した数ずつ並列実行される', async () => {
+    const tmp = fs.mkdtempSync(path.join(process.cwd(), 'conc-test-'));
+    tmpDirs.push(tmp);
+    const outputDir = path.join(tmp, 'out');
+    fs.mkdirSync(outputDir);
+
+    const batch = [
+      { url: `http://localhost:${port}/1`, filename: '1' },
+      { url: `http://localhost:${port}/2`, filename: '2' },
+      { url: `http://localhost:${port}/3`, filename: '3' }
+    ];
+
+    const startTimes: number[] = [];
+    const mockShot = jest.fn(async (u: string, outputPath: string) => {
+      startTimes.push(Date.now());
+      await new Promise<void>(resolve => {
+        http.get(u, res => {
+          res.resume();
+          res.on('end', resolve);
+        });
+      });
+      fs.writeFileSync(outputPath, 'x');
+      await new Promise(res => setTimeout(res, 50));
+    });
+
+    const start = Date.now();
+    await screenshotModule.captureBatch(batch, outputDir, mockShot);
+    const duration = Date.now() - start;
+
+    expect(startTimes.length).toBe(3);
+    expect(Math.abs(startTimes[1] - startTimes[0])).toBeLessThan(20);
+    expect(Math.abs(startTimes[2] - startTimes[0])).toBeLessThan(20);
+    expect(duration).toBeGreaterThanOrEqual(45);
+    expect(duration).toBeLessThan(200);
+  });
+});

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -9,6 +9,45 @@ function launchBrowser() {
   });
 }
 
+export function parseArgs(args: string[]) {
+  let concurrency = 1;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--concurrency' || arg === '-c') {
+      const value = args[i + 1];
+      if (value && !value.startsWith('--')) {
+        concurrency = parseInt(value, 10);
+        i++;
+      }
+    } else if (arg.startsWith('--concurrency=')) {
+      concurrency = parseInt(arg.split('=')[1], 10);
+    }
+  }
+  if (!Number.isFinite(concurrency) || concurrency <= 0) {
+    concurrency = 1;
+  }
+  return { concurrency };
+}
+
+export async function captureBatch(
+  batch: { url: string; filename: string }[],
+  outputDir: string,
+  screenshotFn: typeof takeScreenshot = takeScreenshot
+) {
+  await Promise.all(
+    batch.map(async urlConfig => {
+      try {
+        const outputPath = path.join(outputDir, `${urlConfig.filename}.png`);
+        await screenshotFn(urlConfig.url, outputPath);
+        fs.chmodSync(outputPath, 0o666);
+        console.log(`Successfully captured screenshot for: ${urlConfig.url}`);
+      } catch (error) {
+        console.error(`Failed to capture ${urlConfig.url}:`, error);
+      }
+    })
+  );
+}
+
 // テスト用にエクスポート
 export async function takeScreenshot(url: string, outputPath: string): Promise<void> {
   let browser = null;
@@ -32,6 +71,7 @@ export async function takeScreenshot(url: string, outputPath: string): Promise<v
 
 // テスト用にエクスポート
 export async function main(): Promise<void> {
+  const { concurrency } = parseArgs(process.argv.slice(2));
   const config = loadConfig();
   
   try {
@@ -44,16 +84,10 @@ export async function main(): Promise<void> {
     }
     fs.chmodSync(outputDir, 0o777);
 
-    for (const urlConfig of config.urls) {
-      try {
-        const outputPath = path.join(outputDir, `${urlConfig.filename}.png`);
-        await takeScreenshot(urlConfig.url, outputPath);
-        fs.chmodSync(outputPath, 0o666);
-        console.log(`Successfully captured screenshot for: ${urlConfig.url}`);
-      } catch (error) {
-        console.error(`Failed to capture ${urlConfig.url}:`, error);
-        continue;
-      }
+    const queue = [...config.urls];
+    while (queue.length) {
+      const batch = queue.splice(0, concurrency);
+      await captureBatch(batch, outputDir);
     }
   } catch (error) {
     console.error('Fatal error:', error);
@@ -70,5 +104,7 @@ if (process.env.NODE_ENV !== 'test' && !process.env.JEST_WORKER_ID && !process.e
 // テスト用にデフォルトエクスポート
 export default {
   takeScreenshot,
-  main
+  main,
+  parseArgs,
+  captureBatch
 };


### PR DESCRIPTION
## 概要
- concurrency.test.ts を更新し、モックサーバーを利用して並列実行を検証
- テストで外部サイトに依存しないように変更

## テスト結果
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68655f9b788c8321b972d1aeee141b62