### PR TITLE
並列実行数を指定できるオプションをシナリオに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ docker-compose exec app node dist/screenshot.js [--concurrency 3]
 YMLで定義したシナリオとCSVのパラメータを組み合わせてアクションごとに画面を保存します。
 
 ```bash
-docker-compose exec app node dist/scenario.js --scenario env/scenario.yml --params env/params.csv --output output/run1 [--headless false]
+docker-compose exec app node dist/scenario.js --scenario env/scenario.yml --params env/params.csv --output output/run1 [--headless false] [--concurrency 2]
 ```
 
 `--output` (または `-o`) オプションで保存先ディレクトリを指定します。
 `--headless` に `false` を指定するとブラウザを表示したまま実行できます。
+`--concurrency` (または `-c`) を指定すると、同時に実行するシナリオ数を制御できます。
 実行中は各アクションの結果が順次コンソールに表示されます。
 
 `scenario.yml`例:

--- a/__tests__/scenario.test.ts
+++ b/__tests__/scenario.test.ts
@@ -141,7 +141,7 @@ describe('runScenario', () => {
     const mod = await import('../src/scenario.js');
     const outDir = path.join(tmp, 'out');
     const result = mod.parseArgs(['--scenario', scenarioPath, '--params', paramsPath, '--output', outDir]);
-    expect(result).toEqual({ scenarioPath, paramsPath, outputDir: outDir, headless: true });
+    expect(result).toEqual({ scenarioPath, paramsPath, outputDir: outDir, headless: true, concurrency: 1 });
   });
 
   it('--headlessオプションをfalseで解釈できる', async () => {
@@ -155,6 +155,12 @@ describe('runScenario', () => {
     const mod = await import('../src/scenario.js');
     const outDir = path.join(tmp, 'out');
     const result = mod.parseArgs(['--scenario', scenarioPath, '--params', paramsPath, '--output', outDir, '--headless', 'false']);
-    expect(result).toEqual({ scenarioPath, paramsPath, outputDir: outDir, headless: false });
+    expect(result).toEqual({ scenarioPath, paramsPath, outputDir: outDir, headless: false, concurrency: 1 });
+  });
+
+  it('--concurrencyオプションを解釈できる', async () => {
+    const mod = await import('../src/scenario.js');
+    const result = mod.parseArgs(['--concurrency', '3']);
+    expect(result.concurrency).toBe(3);
   });
 });


### PR DESCRIPTION
## 概要
- `scenario.js` に `--concurrency` オプションを追加し、同時に実行するシナリオ数を指定可能にしました
- `runScenario` を並列実行に対応
- `parseArgs` と `main` を更新
- README にオプション説明を追記
- テストを更新し、新たに `--concurrency` の解析テストを追加

## テスト結果
- `npm test` を実行し、全 55 件のテストが成功することを確認しました

------
https://chatgpt.com/codex/tasks/task_e_6865d112fc6c8321880af7b6cd9349fa