### PR TITLE
指定オプションのログ出力を追加

### DIFF
--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -89,6 +89,7 @@ export async function takeScreenshot(url: string, outputPath: string, device?: s
 // テスト用にエクスポート
 export async function main(): Promise<void> {
   const { concurrency, device } = parseArgs(process.argv.slice(2));
+  console.log('指定されたオプション:', { concurrency, device });
   const config = loadConfig();
   
   try {


### PR DESCRIPTION
## 概要
- CLI 実行時に `--concurrency` や `--device` など指定されたオプションをコンソールに出力するようにしました

## テスト
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d897a35088321934815a78ad69bb7